### PR TITLE
Make it possible to suppress machinectl output

### DIFF
--- a/src/bottle.rs
+++ b/src/bottle.rs
@@ -346,13 +346,16 @@ pub fn exec(cmdline: Vec<String>, uid: nix::unistd::Uid, gid: nix::unistd::Gid) 
     enter(args[0], args.as_slice(), uid, gid)
 }
 
-pub fn shell(uid: Option<nix::unistd::Uid>) -> Result<i32, error::Error> {
+pub fn shell(uid: Option<nix::unistd::Uid>, quiet: bool) -> Result<i32, error::Error> {
     let machinectl = CString::new(environment::machinectl_bin()?).unwrap();
     let mut args = vec![CString::new("machinectl").unwrap(), CString::new("shell").unwrap()];
 
     if let Some(u) = uid {
         args.push(CString::new("--uid").unwrap());
         args.push(CString::new(format!("{}", u)).unwrap());
+    }
+    if quiet {
+        args.push(CString::new("--quiet").unwrap());
     }
 
     args.push(CString::new(".host").unwrap());

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,12 @@ fn main() -> anyhow::Result<()> {
                         .short("s")
                         .long("start"),
                 )
+                .arg(
+                    clap::Arg::with_name("quiet")
+                        .help("Suppress machinectl-shell output")
+                        .short("q")
+                        .long("quiet"),
+                )
                 .arg(clap::Arg::with_name("uid").takes_value(true).short("u").long("uid")),
         )
         .subcommand(
@@ -168,7 +174,8 @@ fn cmd_shell(m: &clap::ArgMatches) -> anyhow::Result<()> {
     }
 
     let (uid, _gid) = extract_uid_gid(m)?;
-    let r = bottle::shell(Some(uid));
+    let quiet = m.is_present("quiet");
+    let r = bottle::shell(Some(uid), quiet);
     match r {
         Ok(retval) => std::process::exit(retval),
         Err(e) => return Err(anyhow::anyhow!("Failed to start: {}", e)),


### PR DESCRIPTION
`subsystemctl shell` produces the message at each time.

```
Connected to the local host. Press ^] three times within 1s to exit
session.
```

This changeset makes it possible to suppress the message by
`subsystemctl shell -q` or `--quiet`.