### PR TITLE
keep the current working directory

### DIFF
--- a/src/bottle.rs
+++ b/src/bottle.rs
@@ -360,12 +360,14 @@ pub fn shell(uid: Option<nix::unistd::Uid>, quiet: bool) -> Result<i32, error::E
         args.push(CString::new("--quiet").unwrap());
     }
 
+    args.push(CString::new("--setenv").unwrap());
+    args.push(CString::new(format!("SUBSYSTEMCTL_PATH={}", std::env::current_dir().unwrap().display())).unwrap());
+
     args.push(CString::new(".host").unwrap());
 
-    let cwd_arg = format!("{}", std::env::current_dir().unwrap().display()).replace("\'", "\'\"\'\"\'");
     args.push(CString::new("/bin/sh").unwrap());
     args.push(CString::new("-c").unwrap());
-    args.push(CString::new(format!("cd '{}'; exec ${{SHELL:-sh}}", cwd_arg)).unwrap());
+    args.push(CString::new("cd \"${SUBSYSTEMCTL_PATH}\"; exec ${SHELL:-sh}").unwrap());
 
     let args_c: Vec<&CStr> = args.iter().map(|s| s.as_c_str()).collect();
     enter(

--- a/src/bottle.rs
+++ b/src/bottle.rs
@@ -362,6 +362,11 @@ pub fn shell(uid: Option<nix::unistd::Uid>, quiet: bool) -> Result<i32, error::E
 
     args.push(CString::new(".host").unwrap());
 
+    let cwd_arg = format!("{}", std::env::current_dir().unwrap().display()).replace("\'", "\'\"\'\"\'");
+    args.push(CString::new("/bin/sh").unwrap());
+    args.push(CString::new("-c").unwrap());
+    args.push(CString::new(format!("cd '{}'; exec ${{SHELL:-sh}}", cwd_arg)).unwrap());
+
     let args_c: Vec<&CStr> = args.iter().map(|s| s.as_c_str()).collect();
     enter(
         machinectl.as_c_str(),
@@ -406,8 +411,6 @@ fn enter(
     use nix::unistd::ForkResult;
 
     setns_systemd();
-
-    // TODO: cwd
 
     match nix::unistd::fork() {
         Ok(ForkResult::Child) => {


### PR DESCRIPTION
Recently, Windows Terminal supports a feature to keep the current working directory when creating a duplicate of a tab.

> The terminal now supports ConEmu’s OSC 9;9 sequence, which sets the current working directory. If you emit OSC 9;9;<Windows path>, creating a duplicate of that pane or tab will use the Windows path you specified (Thanks @skyline75489!).

https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-6-release/

To use this feature, I'd like subsystemctl to keep the cwd.

This PR is very naive implementation to call `machinectl shell .host /bin/sh -c "cd ..CWD; exec ${SHELL:-sh}"`. What do you think?