### PR TITLE
Fix "Specifying uid to login" example; add new example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ someone@hostname$ ...
 #### Specifying uid to login
 
 ```ps1
-PS> wsl -u root -- subsystemctl --uid=1000 shell
+PS> wsl -u root -- subsystemctl shell --uid=1000
 Connected to the local host. Press ^] three times within 1s to exit session.
 someone@hostname$ ...
 ```
@@ -108,6 +108,14 @@ if subsystemctl is-inside; then
 else
   echo "outside"
 fi
+```
+
+#### Automatically starting and entering a user shell
+
+```ps1
+PS> wsl.exe -- sh -c "subsystemctl is-running || subsystemctl start ; subsystemctl shell --uid=1000"
+Connected to the local host. Press ^] three times within 1s to exit session.
+someone@hostname$ ...
 ```
 
 ## Tips

--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ Connected to the local host. Press ^] three times within 1s to exit session.
 someone@hostname$ ...
 ```
 
+#### Automatically starting and entering a user shell
+
+```ps1
+PS> wsl -u root -d Arch -- subsystemctl shell --uid=1000 --start
+[2021-06-27T16:32:20Z INFO  subsystemctl] Starting systemd
+Connected to the local host. Press ^] three times within 1s to exit session.
+
+someone@hostname$ ...
+```
+
 ### `subsystemctl exec`: Raw `nsenter` like interface
 
 ```ps1
@@ -108,14 +118,6 @@ if subsystemctl is-inside; then
 else
   echo "outside"
 fi
-```
-
-#### Automatically starting and entering a user shell
-
-```ps1
-PS> wsl.exe -- sh -c "subsystemctl is-running || subsystemctl start ; subsystemctl shell --uid=1000"
-Connected to the local host. Press ^] three times within 1s to exit session.
-someone@hostname$ ...
 ```
 
 ## Tips


### PR DESCRIPTION
1. `--uid` is a `subsystemctl shell` argument, not a `subsystemctl` argument.
2. the new example is useful in, say, Windows Terminal. It uses `subsystemctl is-running` to check to see if it's running, runs `subsystemctl start` if it isn't, and then runs `subsystem shell --uid=1000`.