### PR TITLE
Forward arguments given as exec command instead of interpreting them as flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,9 @@ fn main() -> anyhow::Result<()> {
                         .short("g")
                         .long("gid"),
                 )
-                .arg(clap::Arg::with_name("command").takes_value(true).index(1).multiple(true)),
+                .arg(clap::Arg::with_name("command").takes_value(true).multiple(true)
+                .allow_hyphen_values(true)
+                .last(true)),
         )
         .subcommand(
             clap::SubCommand::with_name("is-running")


### PR DESCRIPTION
Before patch:
```
subsystemctl exec bash -c echo asdf"
> error: Found argument '-c' which wasn't expected, or isn't valid in this context
```
After patch
```
subsystemctl exec -- bash -c echo "asdf"
> asdf
```
